### PR TITLE
Adding archetypes default file

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,5 @@
++++
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+draft: true
++++


### PR DESCRIPTION
If the variable 'theme' is specified on the site configuration file -  config.toml in this case - and then e.g. create a new post, an error is returned that the archetypes directory is not found. 
Therefore a default.md archetype file must be in place
I think this fixes it - according to the latest modifications from https://github.com/gohugoio/hugo/commit/863a812e07193541b42732b0e227f3d320433f01