### PR TITLE
.URL is deprecated and will be removed in a future release

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
   <title>
-    {{ if eq .URL "/" }}
+    {{ if eq .Permalink "/" }}
       {{ .Site.Params.Title }} &middot; {{ .Site.Params.Tagline }}
     {{ else }}
       {{ .Title }} &middot; {{ .Site.Params.Title }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -9,8 +9,8 @@
   </div>
 
   <nav class="sidebar-nav">
-    <a class="sidebar-nav-item {{ if eq .URL "/" }} active {{ end }}" href="/">Home</a>
-    <a class="sidebar-nav-item {{ if eq .URL "/post/" }} active {{ end }}" href="/post">Posts</a>
+    <a class="sidebar-nav-item {{ if eq .Permalink "/" }} active {{ end }}" href="/">Home</a>
+    <a class="sidebar-nav-item {{ if eq .RelPermalink "/post/" }} active {{ end }}" href="/post">Posts</a>
 
     {{ $thisperma := .Permalink }}
     {{ range .Site.Pages.ByWeight }}


### PR DESCRIPTION
`WARN  Page's .URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink.`

Tested the changes with 0.50, 0.51, 0.52, 0.53, 0.54, 0.55, 0.55.1 for compatibility and found no issues.