### PR TITLE
Add Disqus, Google Analytics and support for Menu Templates

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,6 +4,11 @@
   <h1 class="post-title">{{ .Title }}</h1>
   <span class="post-date">{{ .Site.Params.DateForm | default "Jan 2, 2006" | .Date.Format }}</span>
   {{ .Content }}
+  {{- if .Site.DisqusShortname -}}
+  <hr>
+  <h2>Comments</h2>
+  {{ template "_internal/disqus.html" . }}
+  {{ end -}}
 </div>
 
 {{ partial "default_foot.html" . }}

--- a/layouts/partials/default_foot.html
+++ b/layouts/partials/default_foot.html
@@ -2,6 +2,6 @@
     </div>
 
     <label for="sidebar-checkbox" class="sidebar-toggle"></label>
-
+    {{ template "_internal/google_analytics_async.html" . }}
   </body>
 </html>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -5,7 +5,7 @@
 <!-- Toggleable sidebar -->
 <div class="sidebar" id="sidebar">
   <div class="sidebar-item">
-    <p>A reserved <a href="http://jekyllrb.com" target="_blank">Jekyll</a> theme that places the utmost gravity on content with a hidden drawer. Made by <a href="https://twitter.com/mdo" target="_blank">@mdo</a>.</p>
+    <p>{{ if .Site.Params.description }}{{ .Site.Params.description }}{{ else }}A reserved <a href="http://jekyllrb.com" target="_blank">Jekyll</a> theme that places the utmost gravity on content with a hidden drawer. Made by <a href="https://twitter.com/mdo" target="_blank">@mdo</a>.{{ end }}</p>
   </div>
 
   <nav class="sidebar-nav">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -11,6 +11,10 @@
   <nav class="sidebar-nav">
     <a class="sidebar-nav-item {{ if .IsHome }} active {{ end }}" href="/">Home</a>
     <a class="sidebar-nav-item {{ if eq .RelPermalink "/post/" }} active {{ end }}" href="/post">Posts</a>
+    {{- $currentPage := . }}
+    {{- range .Site.Menus.main -}}
+    <a class="sidebar-nav-item{{if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} active{{end}}" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a>
+    {{- end -}}
 
     {{- $thisperma := .Permalink }}
     {{ range .Site.Pages.ByWeight -}}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -19,9 +19,11 @@
       {{ end -}}
     {{ end -}}
 
-    <a class="sidebar-nav-item" href="{{ .Site.Params.Github.Url }}/archive/{{ .Site.Params.Github.Head }}.zip">Download</a>
-    <a class="sidebar-nav-item" href="{{ .Site.Params.Github.Url }}">GitHub project</a>
-    <span class="sidebar-nav-item">Currently on {{ .Site.Params.Github.Head }}</span>
+    {{- with .Site.Params.Github }}
+    <a class="sidebar-nav-item" href="{{ .url }}/archive/{{ .head }}.zip">Download</a>
+    <a class="sidebar-nav-item" href="{{ .url }}">GitHub project</a>
+    <span class="sidebar-nav-item">Currently on {{ .head }}</span>
+    {{ end -}}
   </nav>
 
   <div class="sidebar-item">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -12,12 +12,12 @@
     <a class="sidebar-nav-item {{ if .IsHome }} active {{ end }}" href="/">Home</a>
     <a class="sidebar-nav-item {{ if eq .RelPermalink "/post/" }} active {{ end }}" href="/post">Posts</a>
 
-    {{ $thisperma := .Permalink }}
-    {{ range .Site.Pages.ByWeight }}
-      {{ if isset .Params "sidebar" }}
+    {{- $thisperma := .Permalink }}
+    {{ range .Site.Pages.ByWeight -}}
+      {{ if isset .Params "sidebar" -}}
         <a class="sidebar-nav-item {{ if eq .Permalink $thisperma }} active {{ end }}" href="{{ .Permalink }}">{{ .Title }}</a>
-      {{ end }}
-    {{ end }}
+      {{ end -}}
+    {{ end -}}
 
     <a class="sidebar-nav-item" href="{{ .Site.Params.Github.Url }}/archive/{{ .Site.Params.Github.Head }}.zip">Download</a>
     <a class="sidebar-nav-item" href="{{ .Site.Params.Github.Url }}">GitHub project</a>


### PR DESCRIPTION
- Add Google Analytics support
  - This is disabled if user doesn't provide `googleAnalytics` in config
- Add Disqus support
  - This is disabled if user doesn't provide `disqusShortname` in config
- Show .Site.Params.description in sidebar if set
- Show GitHub details only if .Site.Params.Github is set
- Add support for Menus (keeping the sidebar: true implementation for backward compatibility)
  - https://gohugo.io/content-management/menus/

Should I add an example to the example site about using the Menus in front matter or in configuration?